### PR TITLE
enabling to use process.ENV if needed to overwrite default `development`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "node": "9.2.0"
   },
   "private": true,
-  "homepage": "https://deafchi.github.io",
+  "homepage": "http://signsfive.com",
   "dependencies": {
-    "auth0-js": "^9.0.2",
+    "auth0-js": "^9.1.3",
     "autoprefixer": "7.1.2",
     "bootstrap": "^4.0.0-beta.2",
     "chalk": "1.1.3",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = 'development';
+process.env.BABEL_ENV = process.env.BABEL_ENV || 'development';
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will


### PR DESCRIPTION
we will want to use `npm run build` for production. Also im going to make ticket for to make it deployed automatically to heroku similar to signsfive.api